### PR TITLE
use SERPAPI_KEY env var in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,11 @@ To enable a type of search, the field tbm (to be matched) must be set to:
 [The full documentation is available here.](https://serpapi.com/search-api)
 
 For pratical example, you can see the test located under test/.
+
+## Development
+
+Tests require an environment variable holding the SERP API key.
+
+```bash
+$ SERPAPI_KEY=**** npm test
+```

--- a/test/GoogleSearchResultsSpec.js
+++ b/test/GoogleSearchResultsSpec.js
@@ -3,7 +3,17 @@ var gsr = require('./../lib/GoogleSearchResults');
 
 describe('Google Search Results', function()
 {
-  let p;
+  let p, serp_api_key;
+
+  before(function()
+  {
+    serp_api_key = process.env.SERPAPI_KEY;
+
+    if (typeof serp_api_key === 'undefined') {
+      throw new Error('Missing required environment variable SERPAPI_KEY');
+    }
+  });
+  
   beforeEach(function()
   {
    p = {q: "Coffee", location: "Austin, Texas"}
@@ -19,16 +29,16 @@ describe('Google Search Results', function()
   it('buildUrl', function() {
     let serp = new gsr.GoogleSearchResults()
     
-    expect(serp.buildUrl(p, "json", "demo")).toBe("https://serpapi.com/search?q=Coffee&location=Austin%2C%20Texas&source=nodejs&output=json&serp_api_key=demo")
+    expect(serp.buildUrl(p, "json", serp_api_key)).toBe(`https://serpapi.com/search?q=Coffee&location=Austin%2C%20Texas&source=nodejs&output=json&serp_api_key=${serp_api_key}`)
   })
   
   it('buildUrl with key in constructor', function() {
-    let serp = new gsr.GoogleSearchResults("demo")
-    expect(serp.buildUrl(p, "json")).toBe("https://serpapi.com/search?q=Coffee&location=Austin%2C%20Texas&source=nodejs&output=json&serp_api_key=demo")
+    let serp = new gsr.GoogleSearchResults(serp_api_key)
+    expect(serp.buildUrl(p, "json")).toBe(`https://serpapi.com/search?q=Coffee&location=Austin%2C%20Texas&source=nodejs&output=json&serp_api_key=${serp_api_key}`)
   })
   
   it("search", (done) => {
-    let serp = new gsr.GoogleSearchResults("demo")
+    let serp = new gsr.GoogleSearchResults(serp_api_key)
     serp.search(p, "json", (raw) => {
       let data = JSON.parse(raw)
       expect(data.local_results[0].title.length).toBeGreaterThan(5)
@@ -37,7 +47,7 @@ describe('Google Search Results', function()
   })
   
   it("json", (done) => {
-    let serp = new gsr.GoogleSearchResults("demo")
+    let serp = new gsr.GoogleSearchResults(serp_api_key)
     serp.json(p, (data) => {
       expect(data.local_results[0].title.length).toBeGreaterThan(5)
       done()
@@ -45,7 +55,7 @@ describe('Google Search Results', function()
   })
   
   it("html", (done) => {
-    let serp = new gsr.GoogleSearchResults("demo")
+    let serp = new gsr.GoogleSearchResults(serp_api_key)
     serp.html(p, (body) => {
       expect(body).toMatch(/<\/html>/)
       done()
@@ -53,7 +63,7 @@ describe('Google Search Results', function()
   })
   
   it("fail:json", () => {
-    let serp = new gsr.GoogleSearchResults("demo")
+    let serp = new gsr.GoogleSearchResults(serp_api_key)
     try {
       serp.json({}, (data) => {
         done()


### PR DESCRIPTION
Minor change that adds a `SERPAPI_KEY` environment variable requirement to the test cases. This mirrors the current Ruby's [query parser tests][3].

Will have to update TravisCI's [environment variables][1] though before merging this in :wink:.

[1]: https://docs-staging.travis-ci.com/user/environment-variables/#defining-encrypted-variables-in-travisyml
[3]: https://github.com/serpapi/google-search-results-ruby/blob/183673081975c0cd9bf519c825b1d171d115a39c/test/search_api_spec.rb#L6


